### PR TITLE
1.21.1

### DIFF
--- a/src/main/java/fr/adrien1106/reframed/ReFramed.java
+++ b/src/main/java/fr/adrien1106/reframed/ReFramed.java
@@ -38,6 +38,7 @@ public class ReFramed implements ModInitializer {
 	public static final ArrayList<Block> BLOCKS = new ArrayList<>();
 	public static ReFramedBlock
         CUBE,
+        CARPET,
         SMALL_CUBE, SMALL_CUBES_STEP,
         STAIR, STAIRS_CUBE,
         HALF_STAIR, HALF_STAIRS_SLAB, HALF_STAIRS_STAIR, HALF_STAIRS_CUBE_STAIR, HALF_STAIRS_STEP_STAIR,
@@ -63,7 +64,8 @@ public class ReFramed implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		CUBE                    = registerBlock("cube"                   , new ReFramedBlock(cp(Blocks.OAK_PLANKS)));
-		SMALL_CUBE              = registerBlock("small_cube"             , new ReFramedSmallCubeBlock(cp(Blocks.OAK_PLANKS)));
+        CARPET                  = registerBlock("carpet"                 , new ReFramedCarpetBlock(cp(Blocks.OAK_SLAB)));
+        SMALL_CUBE              = registerBlock("small_cube"             , new ReFramedSmallCubeBlock(cp(Blocks.OAK_PLANKS)));
 	  	SMALL_CUBES_STEP        = registerBlock("small_cubes_step"       , new ReFramedSmallCubesStepBlock(cp(Blocks.OAK_PLANKS)));
 		STAIR                   = registerBlock("stair"                  , new ReFramedStairBlock(cp(Blocks.OAK_STAIRS)));
 		STAIRS_CUBE             = registerBlock("stairs_cube"            , new ReFramedStairsCubeBlock(cp(Blocks.OAK_STAIRS)));

--- a/src/main/java/fr/adrien1106/reframed/ReFramed.java
+++ b/src/main/java/fr/adrien1106/reframed/ReFramed.java
@@ -39,6 +39,7 @@ public class ReFramed implements ModInitializer {
 	public static ReFramedBlock
         CUBE,
         CARPET,
+        SLOPE_FULL,
         SMALL_CUBE, SMALL_CUBES_STEP,
         STAIR, STAIRS_CUBE,
         HALF_STAIR, HALF_STAIRS_SLAB, HALF_STAIRS_STAIR, HALF_STAIRS_CUBE_STAIR, HALF_STAIRS_STEP_STAIR,
@@ -65,6 +66,7 @@ public class ReFramed implements ModInitializer {
 	public void onInitialize() {
 		CUBE                    = registerBlock("cube"                   , new ReFramedBlock(cp(Blocks.OAK_PLANKS)));
         CARPET                  = registerBlock("carpet"                 , new ReFramedCarpetBlock(cp(Blocks.OAK_SLAB)));
+        SLOPE_FULL              = registerBlock("slope_full"             , new ReFramedSlopeFullBlock(cp(Blocks.OAK_PLANKS)));
         SMALL_CUBE              = registerBlock("small_cube"             , new ReFramedSmallCubeBlock(cp(Blocks.OAK_PLANKS)));
 	  	SMALL_CUBES_STEP        = registerBlock("small_cubes_step"       , new ReFramedSmallCubesStepBlock(cp(Blocks.OAK_PLANKS)));
 		STAIR                   = registerBlock("stair"                  , new ReFramedStairBlock(cp(Blocks.OAK_STAIRS)));

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedCarpetBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedCarpetBlock.java
@@ -1,0 +1,51 @@
+package fr.adrien1106.reframed.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.WorldView;
+import net.minecraft.block.ShapeContext;
+
+public class ReFramedCarpetBlock extends ReFramedBlock {
+
+    private static final VoxelShape SHAPE =
+            Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 1.0, 16.0);
+
+    public ReFramedCarpetBlock(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
+        BlockPos below = pos.down();
+        BlockState belowState = world.getBlockState(below);
+        return belowState.isSideSolidFullSquare(world, below, Direction.UP);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public VoxelShape getOutlineShape(
+            BlockState state,
+            BlockView world,
+            BlockPos pos,
+            ShapeContext context
+    ) {
+        return SHAPE;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public VoxelShape getCollisionShape(
+            BlockState state,
+            BlockView world,
+            BlockPos pos,
+            ShapeContext context
+    ) {
+        return VoxelShapes.empty();
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedDoorBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedDoorBlock.java
@@ -154,23 +154,22 @@ public class ReFramedDoorBlock extends WaterloggableReFramedBlock {
 
     @Override
     @SuppressWarnings("deprecation")
-    protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
-        if (!state.get(HAND_OPENABLE)) {
-            return ActionResult.PASS;
-        }
+    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
 
         ActionResult result = super.onUse(state, world, pos, player, hit);
-        if (result.isAccepted()) return result;
-
-        for (Hand hand : Hand.values()) {
-            flip(state, world, pos, player);
-            break;
+        if (result.isAccepted()) {
+            return result;
         }
 
+        if (!state.get(HAND_OPENABLE)) {
+            return ActionResult.success(world.isClient);
+        }
+
+        flip(state, world, pos, player);
         return ActionResult.success(world.isClient);
     }
 
-    
+
     public boolean canPathfindThrough(BlockState state, BlockView world, BlockPos pos, NavigationType type) {
         return switch (type) {
             case LAND, AIR -> state.get(OPEN);

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedDoorBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedDoorBlock.java
@@ -31,6 +31,7 @@ import net.minecraft.world.WorldView;
 import net.minecraft.world.event.GameEvent;
 import net.minecraft.world.explosion.Explosion;
 import org.jetbrains.annotations.Nullable;
+import net.minecraft.state.property.BooleanProperty;
 
 import java.util.function.BiConsumer;
 
@@ -40,6 +41,8 @@ public class ReFramedDoorBlock extends WaterloggableReFramedBlock {
 
     public static final VoxelShape[] DOOR_VOXELS;
 
+    public static final BooleanProperty HAND_OPENABLE = BooleanProperty.of("hand_openable");
+
     public ReFramedDoorBlock(Settings settings) {
         super(settings);
         setDefaultState(getDefaultState()
@@ -48,12 +51,13 @@ public class ReFramedDoorBlock extends WaterloggableReFramedBlock {
             .with(DOUBLE_BLOCK_HALF, DoubleBlockHalf.LOWER)
             .with(OPEN, false)
             .with(POWERED, false)
+            .with(HAND_OPENABLE, true)
         );
     }
 
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        super.appendProperties(builder.add(HORIZONTAL_FACING, DOOR_HINGE, DOUBLE_BLOCK_HALF, OPEN, POWERED));
+        super.appendProperties(builder.add(HORIZONTAL_FACING, DOOR_HINGE, DOUBLE_BLOCK_HALF, OPEN, POWERED, HAND_OPENABLE));
     }
 
     @Override
@@ -151,9 +155,18 @@ public class ReFramedDoorBlock extends WaterloggableReFramedBlock {
     @Override
     @SuppressWarnings("deprecation")
     protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
+        if (!state.get(HAND_OPENABLE)) {
+            return ActionResult.PASS;
+        }
+
         ActionResult result = super.onUse(state, world, pos, player, hit);
         if (result.isAccepted()) return result;
-        flip(state, world, pos, player);
+
+        for (Hand hand : Hand.values()) {
+            flip(state, world, pos, player);
+            break;
+        }
+
         return ActionResult.success(world.isClient);
     }
 

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
@@ -1,0 +1,103 @@
+package fr.adrien1106.reframed.block;
+
+import fr.adrien1106.reframed.util.blocks.BlockHelper;
+import fr.adrien1106.reframed.util.blocks.Edge;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.item.ItemPlacementContext;
+import net.minecraft.state.StateManager;
+import net.minecraft.util.BlockMirror;
+import net.minecraft.util.BlockRotation;
+import net.minecraft.util.function.BooleanBiFunction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import org.jetbrains.annotations.Nullable;
+import fr.adrien1106.reframed.util.VoxelHelper;
+
+import java.util.stream.Stream;
+
+import static fr.adrien1106.reframed.util.VoxelHelper.VoxelListBuilder;
+import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
+import static net.minecraft.util.shape.VoxelShapes.combineAndSimplify;
+
+public class ReFramedSlopeFullBlock extends WaterloggableReFramedBlock {
+
+    public static final VoxelShape[] SLOPE_VOXELS;
+
+    public ReFramedSlopeFullBlock(Settings settings) {
+        super(settings);
+        setDefaultState(getDefaultState().with(EDGE, Edge.DOWN_SOUTH));
+    }
+
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        super.appendProperties(builder.add(EDGE));
+    }
+
+    @Nullable
+    @Override
+    public BlockState getPlacementState(ItemPlacementContext ctx) {
+        Edge edge = BlockHelper.getPlacementEdge(ctx);
+        return super.getPlacementState(ctx).with(EDGE, edge);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        return getSlopeShape(state.get(EDGE));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, BlockRotation rotation) {
+        return state.with(EDGE, state.get(EDGE).rotate(rotation));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, BlockMirror mirror) {
+        return state.with(EDGE, state.get(EDGE).mirror(mirror));
+    }
+
+    public static VoxelShape getSlopeShape(Edge edge) {
+        return SLOPE_VOXELS[edge.getID()];
+    }
+
+    static {
+
+        VoxelShape BASE_SLOPE = Stream.of(
+                createCuboidShape(0, 0, 0, 16, 1, 16),
+                createCuboidShape(0, 1, 1, 16, 2, 16),
+                createCuboidShape(0, 2, 2, 16, 3, 16),
+                createCuboidShape(0, 3, 3, 16, 4, 16),
+                createCuboidShape(0, 4, 4, 16, 5, 16),
+                createCuboidShape(0, 5, 5, 16, 6, 16),
+                createCuboidShape(0, 6, 6, 16, 7, 16),
+                createCuboidShape(0, 7, 7, 16, 8, 16),
+                createCuboidShape(0, 8, 8, 16, 9, 16),
+                createCuboidShape(0, 9, 9, 16, 10, 16),
+                createCuboidShape(0, 10, 10, 16, 11, 16),
+                createCuboidShape(0, 11, 11, 16, 12, 16),
+                createCuboidShape(0, 12, 12, 16, 13, 16),
+                createCuboidShape(0, 13, 13, 16, 14, 16),
+                createCuboidShape(0, 14, 14, 16, 15, 16),
+                createCuboidShape(0, 15, 15, 16, 16, 16)
+        ).reduce((v1, v2) -> combineAndSimplify(v1, v2, BooleanBiFunction.OR)).get();
+
+        SLOPE_VOXELS = VoxelListBuilder.create(BASE_SLOPE, 12)
+                .add(shape -> VoxelHelper.rotateY(VoxelHelper.rotateY(shape)))
+                .add(0, VoxelHelper::rotateX, VoxelHelper::rotateX)
+                .add(2, VoxelHelper::rotateY, VoxelHelper::rotateY)
+                .add(0, VoxelHelper::rotateCY)
+                .add(4, VoxelHelper::rotateY, VoxelHelper::rotateY)
+                .add(5, VoxelHelper::rotateX, VoxelHelper::rotateX)
+                .add(6, VoxelHelper::rotateY, VoxelHelper::rotateY)
+                .add(0, VoxelHelper::rotateZ)
+                .add(8, VoxelHelper::rotateY)
+                .add(9, VoxelHelper::rotateY)
+                .add(10, VoxelHelper::rotateY)
+                .build();
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
@@ -1,5 +1,6 @@
 package fr.adrien1106.reframed.block;
 
+import fr.adrien1106.reframed.util.VoxelHelper;
 import fr.adrien1106.reframed.util.blocks.BlockHelper;
 import fr.adrien1106.reframed.util.blocks.Edge;
 import net.minecraft.block.Block;
@@ -11,10 +12,12 @@ import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import org.jetbrains.annotations.Nullable;
-import fr.adrien1106.reframed.util.VoxelHelper;
 
 import java.util.stream.Stream;
 
@@ -39,8 +42,43 @@ public class ReFramedSlopeFullBlock extends WaterloggableReFramedBlock {
     @Nullable
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
-        Edge edge = BlockHelper.getPlacementEdge(ctx);
+        Edge edge = getSlopePlacementEdge(ctx);
         return super.getPlacementState(ctx).with(EDGE, edge);
+    }
+
+    private Edge getSlopePlacementEdge(ItemPlacementContext ctx) {
+        Direction clickedFace = ctx.getSide();
+        Vec3d hitPos = BlockHelper.getHitPos(ctx.getHitPos(), ctx.getBlockPos());
+
+        Direction.Axis parallelAxis = getParallelAxis(hitPos, clickedFace);
+        Direction slopeDirection =
+                BlockHelper.getHitDirection(parallelAxis, hitPos);
+
+        if (clickedFace.getAxis() == Direction.Axis.Y) {
+
+            slopeDirection = slopeDirection.getOpposite();
+        } else if (parallelAxis != Direction.Axis.Y) {
+
+            slopeDirection = slopeDirection.getOpposite();
+        }
+
+        Direction baseFace =
+                clickedFace.getAxis() == Direction.Axis.Y
+                        ? clickedFace.getOpposite()
+                        : clickedFace;
+
+        return Edge.getByDirections(baseFace, slopeDirection);
+    }
+
+    private Direction.Axis getParallelAxis(Vec3d hitPos, Direction clickedFace) {
+        return Stream.of(Direction.Axis.values())
+                .filter(axis -> axis != clickedFace.getAxis())
+                .reduce((axis1, axis2) ->
+                        Math.abs(axis1.choose(hitPos.x, hitPos.y, hitPos.z)) >
+                                Math.abs(axis2.choose(hitPos.x, hitPos.y, hitPos.z))
+                                ? axis1 : axis2
+                )
+                .orElse(Direction.Axis.X);
     }
 
     @Override
@@ -66,7 +104,6 @@ public class ReFramedSlopeFullBlock extends WaterloggableReFramedBlock {
     }
 
     static {
-
         VoxelShape BASE_SLOPE = Stream.of(
                 createCuboidShape(0, 0, 0, 16, 2, 16),
                 createCuboidShape(0, 2, 2, 16, 4, 16),

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
@@ -68,22 +68,14 @@ public class ReFramedSlopeFullBlock extends WaterloggableReFramedBlock {
     static {
 
         VoxelShape BASE_SLOPE = Stream.of(
-                createCuboidShape(0, 0, 0, 16, 1, 16),
-                createCuboidShape(0, 1, 1, 16, 2, 16),
-                createCuboidShape(0, 2, 2, 16, 3, 16),
-                createCuboidShape(0, 3, 3, 16, 4, 16),
-                createCuboidShape(0, 4, 4, 16, 5, 16),
-                createCuboidShape(0, 5, 5, 16, 6, 16),
-                createCuboidShape(0, 6, 6, 16, 7, 16),
-                createCuboidShape(0, 7, 7, 16, 8, 16),
-                createCuboidShape(0, 8, 8, 16, 9, 16),
-                createCuboidShape(0, 9, 9, 16, 10, 16),
-                createCuboidShape(0, 10, 10, 16, 11, 16),
-                createCuboidShape(0, 11, 11, 16, 12, 16),
-                createCuboidShape(0, 12, 12, 16, 13, 16),
-                createCuboidShape(0, 13, 13, 16, 14, 16),
-                createCuboidShape(0, 14, 14, 16, 15, 16),
-                createCuboidShape(0, 15, 15, 16, 16, 16)
+                createCuboidShape(0, 0, 0, 16, 2, 16),
+                createCuboidShape(0, 2, 2, 16, 4, 16),
+                createCuboidShape(0, 4, 4, 16, 6, 16),
+                createCuboidShape(0, 6, 6, 16, 8, 16),
+                createCuboidShape(0, 8, 8, 16, 10, 16),
+                createCuboidShape(0, 10, 10, 16, 12, 16),
+                createCuboidShape(0, 12, 12, 16, 14, 16),
+                createCuboidShape(0, 14, 14, 16, 16, 16)
         ).reduce((v1, v2) -> combineAndSimplify(v1, v2, BooleanBiFunction.OR)).get();
 
         SLOPE_VOXELS = VoxelListBuilder.create(BASE_SLOPE, 12)

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedSlopeFullBlock.java
@@ -15,7 +15,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedTrapdoorBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedTrapdoorBlock.java
@@ -90,19 +90,18 @@ public class ReFramedTrapdoorBlock extends WaterloggableReFramedBlock {
 
     @Override
     @SuppressWarnings("deprecation")
-    protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
-        if (!state.get(HAND_OPENABLE)) {
-            return ActionResult.PASS;
-        }
+    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
 
         ActionResult result = super.onUse(state, world, pos, player, hit);
-        if (result.isAccepted()) return result;
-
-        for (Hand hand : Hand.values()) {
-            flip(state, world, pos, player);
-            break;
+        if (result.isAccepted()) {
+            return result;
         }
 
+        if (!state.get(HAND_OPENABLE)) {
+            return ActionResult.success(world.isClient);
+        }
+
+        flip(state, world, pos, player);
         return ActionResult.success(world.isClient);
     }
 

--- a/src/main/java/fr/adrien1106/reframed/block/ReFramedTrapdoorBlock.java
+++ b/src/main/java/fr/adrien1106/reframed/block/ReFramedTrapdoorBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
@@ -32,6 +33,8 @@ public class ReFramedTrapdoorBlock extends WaterloggableReFramedBlock {
 
     public static final VoxelShape[] TRAPDOOR_VOXELS;
 
+    public static final BooleanProperty HAND_OPENABLE = BooleanProperty.of("hand_openable");
+
     public ReFramedTrapdoorBlock(Settings settings) {
         super(settings);
         setDefaultState(getDefaultState()
@@ -39,12 +42,13 @@ public class ReFramedTrapdoorBlock extends WaterloggableReFramedBlock {
             .with(BLOCK_HALF, BlockHalf.BOTTOM)
             .with(OPEN, false)
             .with(POWERED, false)
+            .with(HAND_OPENABLE, true)
         );
     }
 
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        super.appendProperties(builder.add(HORIZONTAL_FACING, BLOCK_HALF, OPEN, POWERED));
+        super.appendProperties(builder.add(HORIZONTAL_FACING, BLOCK_HALF, OPEN, POWERED, HAND_OPENABLE));
     }
 
     @Override
@@ -87,9 +91,18 @@ public class ReFramedTrapdoorBlock extends WaterloggableReFramedBlock {
     @Override
     @SuppressWarnings("deprecation")
     protected ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, BlockHitResult hit) {
+        if (!state.get(HAND_OPENABLE)) {
+            return ActionResult.PASS;
+        }
+
         ActionResult result = super.onUse(state, world, pos, player, hit);
         if (result.isAccepted()) return result;
-        flip(state, world, pos, player);
+
+        for (Hand hand : Hand.values()) {
+            flip(state, world, pos, player);
+            break;
+        }
+
         return ActionResult.success(world.isClient);
     }
 

--- a/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
+++ b/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
@@ -48,7 +48,7 @@ public class ReFramedClient implements ClientModInitializer {
 		HELPER.addReFramedModel("cube"                          , HELPER.auto(Identifier.ofVanilla("block/cube")));
         // CARPET
         HELPER.addReFramedModel("carpet"                        , HELPER.auto(ReFramed.id("block/carpet")));
-        // SLOPE_FULL - ADD THESE LINES
+        // SLOPE_FULL
         HELPER.addReFramedModel("slope_full"                    , new UnbakedSlopeModel(ReFramed.id("block/slope_full")));
 		// SMALL_CUBE
 		HELPER.addReFramedModel("small_cube"                    , HELPER.auto(ReFramed.id("block/small_cube/base")));

--- a/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
+++ b/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
@@ -13,6 +13,7 @@ import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ChunkSectionPos;
+import fr.adrien1106.reframed.client.model.UnbakedSlopeModel;
 
 public class ReFramedClient implements ClientModInitializer {
 	public static final ReFramedModelProvider PROVIDER = new ReFramedModelProvider();
@@ -47,6 +48,8 @@ public class ReFramedClient implements ClientModInitializer {
 		HELPER.addReFramedModel("cube"                          , HELPER.auto(Identifier.ofVanilla("block/cube")));
         // CARPET
         HELPER.addReFramedModel("carpet"                        , HELPER.auto(ReFramed.id("block/carpet")));
+        // SLOPE_FULL - ADD THESE LINES
+        HELPER.addReFramedModel("slope_full"                    , new UnbakedSlopeModel(ReFramed.id("block/slope_full")));
 		// SMALL_CUBE
 		HELPER.addReFramedModel("small_cube"                    , HELPER.auto(ReFramed.id("block/small_cube/base")));
 		// SMALL_CUBES_STEP
@@ -238,6 +241,7 @@ public class ReFramedClient implements ClientModInitializer {
 		// item model assignments (in lieu of models/item/___.json)
 		HELPER.assignItemModel("cube"                    , ReFramed.CUBE);
         HELPER.assignItemModel("carpet"                  , ReFramed.CARPET);
+        HELPER.assignItemModel("slope_full"              , ReFramed.SLOPE_FULL);
         HELPER.assignItemModel("small_cube"              , ReFramed.SMALL_CUBE);
 		HELPER.assignItemModel("small_cubes_step"        , ReFramed.SMALL_CUBES_STEP);
 		HELPER.assignItemModel("slab"                    , ReFramed.SLAB);

--- a/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
+++ b/src/main/java/fr/adrien1106/reframed/client/ReFramedClient.java
@@ -45,6 +45,8 @@ public class ReFramedClient implements ClientModInitializer {
 
 		// CUBE
 		HELPER.addReFramedModel("cube"                          , HELPER.auto(Identifier.ofVanilla("block/cube")));
+        // CARPET
+        HELPER.addReFramedModel("carpet"                        , HELPER.auto(ReFramed.id("block/carpet")));
 		// SMALL_CUBE
 		HELPER.addReFramedModel("small_cube"                    , HELPER.auto(ReFramed.id("block/small_cube/base")));
 		// SMALL_CUBES_STEP
@@ -235,7 +237,8 @@ public class ReFramedClient implements ClientModInitializer {
 
 		// item model assignments (in lieu of models/item/___.json)
 		HELPER.assignItemModel("cube"                    , ReFramed.CUBE);
-		HELPER.assignItemModel("small_cube"              , ReFramed.SMALL_CUBE);
+        HELPER.assignItemModel("carpet"                  , ReFramed.CARPET);
+        HELPER.assignItemModel("small_cube"              , ReFramed.SMALL_CUBE);
 		HELPER.assignItemModel("small_cubes_step"        , ReFramed.SMALL_CUBES_STEP);
 		HELPER.assignItemModel("slab"                    , ReFramed.SLAB);
 		HELPER.assignItemModel("double_slab"             , ReFramed.SLABS_CUBE);

--- a/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
@@ -1,0 +1,102 @@
+package fr.adrien1106.reframed.client.model;
+
+import fr.adrien1106.reframed.client.ReFramedClient;
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
+import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+import net.minecraft.util.math.Direction;
+
+public class SlopeFullMesh {
+
+    public static Mesh getSlopeMesh() {
+        Renderer renderer = ReFramedClient.HELPER.getFabricRenderer();
+        MeshBuilder builder = renderer.meshBuilder();
+        QuadEmitter emitter = builder.getEmitter();
+
+        emitter
+                .pos(0, 0f, 0f, 0f)
+                .pos(1, 1f, 0f, 0f)
+                .pos(2, 1f, 1f, 1f)
+                .pos(3, 0f, 1f, 1f)
+                .uv(0, 0f, 0f)
+                .uv(1, 1f, 0f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(null)
+                .nominalFace(Direction.UP)
+                .tag(Direction.UP.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 0f, 0f)
+                .pos(1, 0f, 1f, 1f)
+                .pos(2, 0f, 0f, 1f)
+                .pos(3, 0f, 0f, 0f)
+                .uv(0, 0f, 0f)
+                .uv(1, 0f, 1f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 0f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.WEST)
+                .nominalFace(Direction.WEST)
+                .tag(Direction.WEST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 1f, 0f, 1f)
+                .pos(1, 1f, 1f, 1f)
+                .pos(2, 1f, 0f, 0f)
+                .pos(3, 1f, 0f, 1f)
+                .uv(0, 1f, 1f)
+                .uv(1, 1f, 0f)
+                .uv(2, 0f, 0f)
+                .uv(3, 1f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.EAST)
+                .nominalFace(Direction.EAST)
+                .tag(Direction.EAST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 1f, 0f, 0f)
+                .pos(1, 1f, 0f, 0f)
+                .pos(2, 0f, 0f, 0f)
+                .pos(3, 0f, 0f, 0f)
+                .uv(0, 1f, 1f)
+                .uv(1, 1f, 1f)
+                .uv(2, 0f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.NORTH)
+                .nominalFace(Direction.NORTH)
+                .tag(Direction.NORTH.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 1f, 1f)
+                .pos(1, 1f, 1f, 1f)
+                .pos(2, 1f, 1f, 1f)
+                .pos(3, 0f, 1f, 1f)
+                .uv(0, 0f, 0f)
+                .uv(1, 1f, 0f)
+                .uv(2, 1f, 0f)
+                .uv(3, 0f, 0f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.SOUTH)
+                .nominalFace(Direction.SOUTH)
+                .tag(Direction.SOUTH.ordinal() + 1)
+                .emit();
+
+        emitter
+                .square(Direction.DOWN, 0, 0, 1, 1, 0)
+                .uvUnitSquare()
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.DOWN)
+                .tag(Direction.DOWN.ordinal() + 1)
+                .emit();
+
+        return builder.build();
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
@@ -56,8 +56,8 @@ public final class SlopeFullMesh {
         e.emit();
 
         e.pos(0, 1f, 0f, 0f);
-        e.pos(1, 1f, 0f, 1f);
-        e.pos(2, 1f, 1f, 1f);
+        e.pos(1, 1f, 1f, 1f);
+        e.pos(2, 1f, 0f, 1f);
         e.pos(3, 1f, 0f, 0f);
 
         e.uv(0, 0f, 1f);
@@ -72,9 +72,9 @@ public final class SlopeFullMesh {
         e.emit();
 
         e.pos(0, 0f, 0f, 0f);
-        e.pos(1, 1f, 0f, 0f);
+        e.pos(1, 0f, 1f, 1f);
         e.pos(2, 1f, 1f, 1f);
-        e.pos(3, 0f, 1f, 1f);
+        e.pos(3, 1f, 0f, 0f);
 
         e.uv(0, 0f, 1f);
         e.uv(1, 1f, 1f);

--- a/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
@@ -99,4 +99,95 @@ public class SlopeFullMesh {
 
         return builder.build();
     }
+
+    public static Mesh getItemMesh() {
+        Renderer renderer = ReFramedClient.HELPER.getFabricRenderer();
+        MeshBuilder builder = renderer.meshBuilder();
+        QuadEmitter emitter = builder.getEmitter();
+
+        emitter
+                .pos(0, 0f, 1f, 1f)
+                .pos(1, 1f, 1f, 1f)
+                .pos(2, 1f, 0f, 0f)
+                .pos(3, 0f, 0f, 0f)
+                .uv(0, 0f, 1f)
+                .uv(1, 1f, 1f)
+                .uv(2, 1f, 0f)
+                .uv(3, 0f, 0f)
+                .color(-1, -1, -1, -1)
+                .cullFace(null)
+                .nominalFace(Direction.UP)
+                .tag(Direction.UP.ordinal() + 1)
+                .emit();
+
+        emitter
+                .square(Direction.DOWN, 0, 0, 1, 1, 0)
+                .uvUnitSquare()
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.DOWN)
+                .tag(Direction.DOWN.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 1f, 0f, 0f)
+                .pos(1, 1f, 1f, 1f)
+                .pos(2, 1f, 0f, 1f)
+                .pos(3, 1f, 0f, 0f)
+                .uv(0, 0f, 1f)
+                .uv(1, 0f, 0f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.EAST)
+                .nominalFace(Direction.EAST)
+                .tag(Direction.EAST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 0f, 1f)
+                .pos(1, 0f, 1f, 1f)
+                .pos(2, 0f, 0f, 0f)
+                .pos(3, 0f, 0f, 1f)
+                .uv(0, 1f, 1f)
+                .uv(1, 1f, 0f)
+                .uv(2, 0f, 1f)
+                .uv(3, 1f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.WEST)
+                .nominalFace(Direction.WEST)
+                .tag(Direction.WEST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 0f, 1f)
+                .pos(1, 1f, 0f, 1f)
+                .pos(2, 1f, 0f, 1f)
+                .pos(3, 0f, 0f, 1f)
+                .uv(0, 0f, 1f)
+                .uv(1, 1f, 1f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.SOUTH)
+                .nominalFace(Direction.SOUTH)
+                .tag(Direction.SOUTH.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 1f, 1f)
+                .pos(1, 1f, 1f, 1f)
+                .pos(2, 1f, 0f, 1f)
+                .pos(3, 0f, 0f, 1f)
+                .uv(0, 0f, 0f)
+                .uv(1, 1f, 0f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.NORTH)
+                .nominalFace(Direction.NORTH)
+                .tag(Direction.NORTH.ordinal() + 1)
+                .emit();
+
+        return builder.build();
+    }
 }

--- a/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
@@ -15,78 +15,18 @@ public class SlopeFullMesh {
         QuadEmitter emitter = builder.getEmitter();
 
         emitter
-                .pos(0, 0f, 0f, 0f)
-                .pos(1, 1f, 0f, 0f)
-                .pos(2, 1f, 1f, 1f)
-                .pos(3, 0f, 1f, 1f)
-                .uv(0, 0f, 0f)
-                .uv(1, 1f, 0f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
+                .pos(0, 1f, 1f, 0f)
+                .pos(1, 0f, 1f, 0f)
+                .pos(2, 0f, 0f, 1f)
+                .pos(3, 1f, 0f, 1f)
+                .uv(0, 1f, 0f)
+                .uv(1, 0f, 0f)
+                .uv(2, 0f, 1f)
+                .uv(3, 1f, 1f)
                 .color(-1, -1, -1, -1)
                 .cullFace(null)
                 .nominalFace(Direction.UP)
                 .tag(Direction.UP.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 0f, 0f, 0f)
-                .pos(1, 0f, 1f, 1f)
-                .pos(2, 0f, 0f, 1f)
-                .pos(3, 0f, 0f, 0f)
-                .uv(0, 0f, 0f)
-                .uv(1, 0f, 1f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 0f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.WEST)
-                .nominalFace(Direction.WEST)
-                .tag(Direction.WEST.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 1f, 0f, 1f)
-                .pos(1, 1f, 1f, 1f)
-                .pos(2, 1f, 0f, 0f)
-                .pos(3, 1f, 0f, 1f)
-                .uv(0, 1f, 1f)
-                .uv(1, 1f, 0f)
-                .uv(2, 0f, 0f)
-                .uv(3, 1f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.EAST)
-                .nominalFace(Direction.EAST)
-                .tag(Direction.EAST.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 1f, 0f, 0f)
-                .pos(1, 1f, 0f, 0f)
-                .pos(2, 0f, 0f, 0f)
-                .pos(3, 0f, 0f, 0f)
-                .uv(0, 1f, 1f)
-                .uv(1, 1f, 1f)
-                .uv(2, 0f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.NORTH)
-                .nominalFace(Direction.NORTH)
-                .tag(Direction.NORTH.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 0f, 1f, 1f)
-                .pos(1, 1f, 1f, 1f)
-                .pos(2, 1f, 1f, 1f)
-                .pos(3, 0f, 1f, 1f)
-                .uv(0, 0f, 0f)
-                .uv(1, 1f, 0f)
-                .uv(2, 1f, 0f)
-                .uv(3, 0f, 0f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.SOUTH)
-                .nominalFace(Direction.SOUTH)
-                .tag(Direction.SOUTH.ordinal() + 1)
                 .emit();
 
         emitter
@@ -95,6 +35,66 @@ public class SlopeFullMesh {
                 .color(-1, -1, -1, -1)
                 .cullFace(Direction.DOWN)
                 .tag(Direction.DOWN.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 0f, 1f)
+                .pos(1, 0f, 1f, 0f)
+                .pos(2, 0f, 0f, 0f)
+                .pos(3, 0f, 0f, 1f)
+                .uv(0, 1f, 1f)
+                .uv(1, 1f, 0f)
+                .uv(2, 0f, 1f)
+                .uv(3, 1f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.WEST)
+                .nominalFace(Direction.WEST)
+                .tag(Direction.WEST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 1f, 0f, 0f)
+                .pos(1, 1f, 1f, 0f)
+                .pos(2, 1f, 0f, 1f)
+                .pos(3, 1f, 0f, 0f)
+                .uv(0, 0f, 1f)
+                .uv(1, 0f, 0f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.EAST)
+                .nominalFace(Direction.EAST)
+                .tag(Direction.EAST.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 1f, 0f)
+                .pos(1, 1f, 1f, 0f)
+                .pos(2, 1f, 0f, 0f)
+                .pos(3, 0f, 0f, 0f)
+                .uv(0, 0f, 0f)
+                .uv(1, 1f, 0f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.NORTH)
+                .nominalFace(Direction.NORTH)
+                .tag(Direction.NORTH.ordinal() + 1)
+                .emit();
+
+        emitter
+                .pos(0, 0f, 0f, 1f)
+                .pos(1, 1f, 0f, 1f)
+                .pos(2, 1f, 0f, 1f)
+                .pos(3, 0f, 0f, 1f)
+                .uv(0, 0f, 1f)
+                .uv(1, 1f, 1f)
+                .uv(2, 1f, 1f)
+                .uv(3, 0f, 1f)
+                .color(-1, -1, -1, -1)
+                .cullFace(Direction.SOUTH)
+                .nominalFace(Direction.SOUTH)
+                .tag(Direction.SOUTH.ordinal() + 1)
                 .emit();
 
         return builder.build();

--- a/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/SlopeFullMesh.java
@@ -7,186 +7,85 @@ import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.minecraft.util.math.Direction;
 
-public class SlopeFullMesh {
+public final class SlopeFullMesh {
 
-    public static Mesh getSlopeMesh() {
-        Renderer renderer = ReFramedClient.HELPER.getFabricRenderer();
-        MeshBuilder builder = renderer.meshBuilder();
-        QuadEmitter emitter = builder.getEmitter();
+    private SlopeFullMesh() {}
 
-        emitter
-                .pos(0, 1f, 1f, 0f)
-                .pos(1, 0f, 1f, 0f)
-                .pos(2, 0f, 0f, 1f)
-                .pos(3, 1f, 0f, 1f)
-                .uv(0, 1f, 0f)
-                .uv(1, 0f, 0f)
-                .uv(2, 0f, 1f)
-                .uv(3, 1f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(null)
-                .nominalFace(Direction.UP)
-                .tag(Direction.UP.ordinal() + 1)
-                .emit();
+    private static Mesh BASE_MESH;
 
-        emitter
-                .square(Direction.DOWN, 0, 0, 1, 1, 0)
-                .uvUnitSquare()
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.DOWN)
-                .tag(Direction.DOWN.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 0f, 0f, 1f)
-                .pos(1, 0f, 1f, 0f)
-                .pos(2, 0f, 0f, 0f)
-                .pos(3, 0f, 0f, 1f)
-                .uv(0, 1f, 1f)
-                .uv(1, 1f, 0f)
-                .uv(2, 0f, 1f)
-                .uv(3, 1f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.WEST)
-                .nominalFace(Direction.WEST)
-                .tag(Direction.WEST.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 1f, 0f, 0f)
-                .pos(1, 1f, 1f, 0f)
-                .pos(2, 1f, 0f, 1f)
-                .pos(3, 1f, 0f, 0f)
-                .uv(0, 0f, 1f)
-                .uv(1, 0f, 0f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.EAST)
-                .nominalFace(Direction.EAST)
-                .tag(Direction.EAST.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 0f, 1f, 0f)
-                .pos(1, 1f, 1f, 0f)
-                .pos(2, 1f, 0f, 0f)
-                .pos(3, 0f, 0f, 0f)
-                .uv(0, 0f, 0f)
-                .uv(1, 1f, 0f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.NORTH)
-                .nominalFace(Direction.NORTH)
-                .tag(Direction.NORTH.ordinal() + 1)
-                .emit();
-
-        emitter
-                .pos(0, 0f, 0f, 1f)
-                .pos(1, 1f, 0f, 1f)
-                .pos(2, 1f, 0f, 1f)
-                .pos(3, 0f, 0f, 1f)
-                .uv(0, 0f, 1f)
-                .uv(1, 1f, 1f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.SOUTH)
-                .nominalFace(Direction.SOUTH)
-                .tag(Direction.SOUTH.ordinal() + 1)
-                .emit();
-
-        return builder.build();
+    public static Mesh getBaseMesh() {
+        if (BASE_MESH == null) {
+            BASE_MESH = buildMesh();
+        }
+        return BASE_MESH;
     }
 
-    public static Mesh getItemMesh() {
+    private static Mesh buildMesh() {
         Renderer renderer = ReFramedClient.HELPER.getFabricRenderer();
         MeshBuilder builder = renderer.meshBuilder();
-        QuadEmitter emitter = builder.getEmitter();
+        QuadEmitter e = builder.getEmitter();
 
-        emitter
-                .pos(0, 0f, 1f, 1f)
-                .pos(1, 1f, 1f, 1f)
-                .pos(2, 1f, 0f, 0f)
-                .pos(3, 0f, 0f, 0f)
-                .uv(0, 0f, 1f)
-                .uv(1, 1f, 1f)
-                .uv(2, 1f, 0f)
-                .uv(3, 0f, 0f)
-                .color(-1, -1, -1, -1)
-                .cullFace(null)
-                .nominalFace(Direction.UP)
-                .tag(Direction.UP.ordinal() + 1)
-                .emit();
+        e.square(Direction.DOWN, 0f, 0f, 1f, 1f, 0f);
+        e.color(-1, -1, -1, -1);
+        e.cullFace(Direction.DOWN);
+        e.nominalFace(Direction.DOWN);
+        e.tag(Direction.DOWN.ordinal() + 1);
+        e.emit();
 
-        emitter
-                .square(Direction.DOWN, 0, 0, 1, 1, 0)
-                .uvUnitSquare()
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.DOWN)
-                .tag(Direction.DOWN.ordinal() + 1)
-                .emit();
+        e.square(Direction.SOUTH, 0f, 0f, 1f, 1f, 0f);
+        e.color(-1, -1, -1, -1);
+        e.cullFace(Direction.SOUTH);
+        e.nominalFace(Direction.SOUTH);
+        e.tag(Direction.SOUTH.ordinal() + 1);
+        e.emit();
 
-        emitter
-                .pos(0, 1f, 0f, 0f)
-                .pos(1, 1f, 1f, 1f)
-                .pos(2, 1f, 0f, 1f)
-                .pos(3, 1f, 0f, 0f)
-                .uv(0, 0f, 1f)
-                .uv(1, 0f, 0f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.EAST)
-                .nominalFace(Direction.EAST)
-                .tag(Direction.EAST.ordinal() + 1)
-                .emit();
+        e.pos(0, 0f, 0f, 0f);
+        e.pos(1, 0f, 0f, 1f);
+        e.pos(2, 0f, 1f, 1f);
+        e.pos(3, 0f, 0f, 0f);
 
-        emitter
-                .pos(0, 0f, 0f, 1f)
-                .pos(1, 0f, 1f, 1f)
-                .pos(2, 0f, 0f, 0f)
-                .pos(3, 0f, 0f, 1f)
-                .uv(0, 1f, 1f)
-                .uv(1, 1f, 0f)
-                .uv(2, 0f, 1f)
-                .uv(3, 1f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.WEST)
-                .nominalFace(Direction.WEST)
-                .tag(Direction.WEST.ordinal() + 1)
-                .emit();
+        e.uv(0, 0f, 1f);
+        e.uv(1, 1f, 1f);
+        e.uv(2, 1f, 0f);
+        e.uv(3, 0f, 1f);
 
-        emitter
-                .pos(0, 0f, 0f, 1f)
-                .pos(1, 1f, 0f, 1f)
-                .pos(2, 1f, 0f, 1f)
-                .pos(3, 0f, 0f, 1f)
-                .uv(0, 0f, 1f)
-                .uv(1, 1f, 1f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.SOUTH)
-                .nominalFace(Direction.SOUTH)
-                .tag(Direction.SOUTH.ordinal() + 1)
-                .emit();
+        e.color(-1, -1, -1, -1);
+        e.cullFace(Direction.WEST);
+        e.nominalFace(Direction.WEST);
+        e.tag(Direction.WEST.ordinal() + 1);
+        e.emit();
 
-        emitter
-                .pos(0, 0f, 1f, 1f)
-                .pos(1, 1f, 1f, 1f)
-                .pos(2, 1f, 0f, 1f)
-                .pos(3, 0f, 0f, 1f)
-                .uv(0, 0f, 0f)
-                .uv(1, 1f, 0f)
-                .uv(2, 1f, 1f)
-                .uv(3, 0f, 1f)
-                .color(-1, -1, -1, -1)
-                .cullFace(Direction.NORTH)
-                .nominalFace(Direction.NORTH)
-                .tag(Direction.NORTH.ordinal() + 1)
-                .emit();
+        e.pos(0, 1f, 0f, 0f);
+        e.pos(1, 1f, 0f, 1f);
+        e.pos(2, 1f, 1f, 1f);
+        e.pos(3, 1f, 0f, 0f);
+
+        e.uv(0, 0f, 1f);
+        e.uv(1, 1f, 1f);
+        e.uv(2, 1f, 0f);
+        e.uv(3, 0f, 1f);
+
+        e.color(-1, -1, -1, -1);
+        e.cullFace(Direction.EAST);
+        e.nominalFace(Direction.EAST);
+        e.tag(Direction.EAST.ordinal() + 1);
+        e.emit();
+
+        e.pos(0, 0f, 0f, 0f);
+        e.pos(1, 1f, 0f, 0f);
+        e.pos(2, 1f, 1f, 1f);
+        e.pos(3, 0f, 1f, 1f);
+
+        e.uv(0, 0f, 1f);
+        e.uv(1, 1f, 1f);
+        e.uv(2, 1f, 0f);
+        e.uv(3, 0f, 0f);
+
+        e.color(-1, -1, -1, -1);
+        e.cullFace(null);
+        e.nominalFace(Direction.UP);
+        e.tag(Direction.UP.ordinal() + 1);
+        e.emit();
 
         return builder.build();
     }

--- a/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
@@ -135,16 +135,21 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
                 matrix.rotateY((float) Math.PI);
                 matrix.rotateX((float) Math.PI);
             }
+
             case DOWN_EAST -> matrix.rotateY((float) (Math.PI / 2));
             case WEST_DOWN -> matrix.rotateY((float) (-Math.PI / 2));
             case EAST_UP -> {
                 matrix.rotateY((float) (Math.PI / 2));
                 matrix.rotateX((float) Math.PI);
+                matrix.rotateY((float) Math.PI);
             }
+
             case UP_WEST -> {
                 matrix.rotateY((float) (-Math.PI / 2));
                 matrix.rotateX((float) Math.PI);
+                matrix.rotateY((float) Math.PI);
             }
+
             case EAST_SOUTH -> matrix.rotateZ((float) (-Math.PI / 2));
             case WEST_NORTH -> matrix.rotateZ((float) (Math.PI / 2));
             case NORTH_EAST -> matrix.rotateZ((float) Math.PI);

--- a/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
@@ -1,0 +1,51 @@
+package fr.adrien1106.reframed.client.model;
+
+import fr.adrien1106.reframed.client.ReFramedClient;
+import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
+import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.Baker;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.SpriteIdentifier;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Function;
+
+public class UnbakedSlopeModel extends UnbakedRetexturedModel {
+
+    private final Mesh baseMesh;
+
+    public UnbakedSlopeModel(Identifier parent) {
+        super(parent);
+        this.baseMesh = SlopeFullMesh.getSlopeMesh();
+        item_state = Blocks.AIR.getDefaultState();
+    }
+
+    @Override
+    public BakedModel bake(Baker baker, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings bakeSettings) {
+        return new RetexturingBakedModel(
+                baker.bake(parent, bakeSettings),
+                ReFramedClient.HELPER.getCamoAppearanceManager(textureGetter),
+                theme_index,
+                bakeSettings,
+                item_state
+        ) {
+            @Override
+            protected Mesh convertModel(BlockState state) {
+                MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
+                QuadEmitter emitter = builder.getEmitter();
+
+                baseMesh.forEach(quad -> {
+                    emitter.copyFrom(quad);
+                    emitter.emit();
+                });
+
+                return builder.build();
+            }
+        };
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
@@ -1,9 +1,12 @@
 package fr.adrien1106.reframed.client.model;
 
+import fr.adrien1106.reframed.block.ReFramedSlopeFullBlock;
 import fr.adrien1106.reframed.client.ReFramedClient;
+import fr.adrien1106.reframed.util.blocks.Edge;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
+import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.render.model.BakedModel;
@@ -12,8 +15,15 @@ import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.SpriteIdentifier;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Direction;
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.function.Function;
+
+import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
 
 public class UnbakedSlopeModel extends UnbakedRetexturedModel {
 
@@ -36,16 +46,116 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         ) {
             @Override
             protected Mesh convertModel(BlockState state) {
+                // Get the edge from the blockstate
+                Edge edge = state != null && state.contains(EDGE)
+                        ? state.get(EDGE)
+                        : Edge.DOWN_SOUTH;
+
                 MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
                 QuadEmitter emitter = builder.getEmitter();
 
+                // Get transformation for this edge orientation
+                RenderContext.QuadTransform transform = getTransformForEdge(edge);
+
+                // Apply transformation to base mesh
                 baseMesh.forEach(quad -> {
                     emitter.copyFrom(quad);
+                    if (transform != null) {
+                        transform.transform(emitter);
+                    }
                     emitter.emit();
                 });
 
                 return builder.build();
             }
         };
+    }
+
+    /**
+     * Get the transformation to apply based on the Edge orientation.
+     * Base mesh is oriented for Edge.DOWN_SOUTH (slope rising from north to south)
+     */
+    private static RenderContext.QuadTransform getTransformForEdge(Edge edge) {
+        Matrix4f matrix = getRotationMatrix(edge);
+        if (matrix == null) return null;
+
+        Map<Direction, Direction> faceMap = createFacePermutation(matrix);
+
+        return quad -> {
+            // Transform vertex positions
+            Vector3f pos = new Vector3f();
+            for (int i = 0; i < 4; i++) {
+                quad.copyPos(i, pos);
+                pos.sub(0.5f, 0.5f, 0.5f); // Center around origin
+                pos.mulPosition(matrix);    // Apply rotation
+                pos.add(0.5f, 0.5f, 0.5f); // Move back
+                quad.pos(i, pos.x(), pos.y(), pos.z());
+            }
+
+            // Transform face directions
+            Direction oldCull = quad.cullFace();
+            if (oldCull != null) {
+                quad.cullFace(faceMap.get(oldCull));
+            }
+
+            Direction oldNominal = quad.nominalFace();
+            if (oldNominal != null) {
+                Direction newNominal = faceMap.get(oldNominal);
+                quad.nominalFace(newNominal);
+                quad.tag(newNominal.ordinal() + 1);
+            }
+
+            return true;
+        };
+    }
+
+    /**
+     * Get the rotation matrix for transforming from base orientation (DOWN_SOUTH)
+     * to the target edge orientation
+     */
+    private static Matrix4f getRotationMatrix(Edge edge) {
+        Matrix4f matrix = new Matrix4f().identity();
+
+        switch (edge) {
+            case DOWN_SOUTH -> { return null; } // Base orientation, no transform
+            case NORTH_DOWN -> matrix.rotateY((float) Math.PI); // 180° around Y
+            case UP_NORTH -> matrix.rotateX((float) Math.PI); // 180° around X
+            case SOUTH_UP -> { // 180° around Y, then 180° around X
+                matrix.rotateY((float) Math.PI);
+                matrix.rotateX((float) Math.PI);
+            }
+            case DOWN_EAST -> matrix.rotateY((float) (Math.PI / 2)); // 90° CW around Y
+            case WEST_DOWN -> matrix.rotateY((float) (-Math.PI / 2)); // 90° CCW around Y
+            case EAST_UP -> { // 90° CW around Y, then 180° around X
+                matrix.rotateY((float) (Math.PI / 2));
+                matrix.rotateX((float) Math.PI);
+            }
+            case UP_WEST -> { // 90° CCW around Y, then 180° around X
+                matrix.rotateY((float) (-Math.PI / 2));
+                matrix.rotateX((float) Math.PI);
+            }
+            case EAST_SOUTH -> matrix.rotateZ((float) (-Math.PI / 2)); // 90° CW around Z
+            case WEST_NORTH -> matrix.rotateZ((float) (Math.PI / 2)); // 90° CCW around Z
+            case NORTH_EAST -> { // 180° around Z
+                matrix.rotateZ((float) Math.PI);
+            }
+            case SOUTH_WEST -> { // 180° around X, then 90° CW around Z
+                matrix.rotateX((float) Math.PI);
+                matrix.rotateZ((float) (-Math.PI / 2));
+            }
+        }
+
+        return matrix;
+    }
+
+    /**
+     * Create a map of how directions transform under the given matrix
+     */
+    private static Map<Direction, Direction> createFacePermutation(Matrix4f matrix) {
+        Map<Direction, Direction> map = new EnumMap<>(Direction.class);
+        for (Direction dir : Direction.values()) {
+            map.put(dir, Direction.transform(matrix, dir));
+        }
+        return map;
     }
 }

--- a/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
@@ -2,10 +2,10 @@ package fr.adrien1106.reframed.client.model;
 
 import fr.adrien1106.reframed.client.ReFramedClient;
 import fr.adrien1106.reframed.util.blocks.Edge;
+import net.fabricmc.fabric.api.renderer.v1.Renderer;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MeshBuilder;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
-import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.render.model.BakedModel;
@@ -13,7 +13,7 @@ import net.minecraft.client.render.model.Baker;
 import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.util.SpriteIdentifier;
-import net.minecraft.util.Identifier;
+import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
 import net.minecraft.util.math.Direction;
 import org.joml.Matrix4f;
 import org.joml.Vector3f;
@@ -22,22 +22,24 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
-
 public class UnbakedSlopeModel extends UnbakedRetexturedModel {
 
-    private final Mesh baseMesh;
-    private final Mesh itemMesh;
+    private static final Mesh[] SLOPE_MESHES = new Mesh[12];
+    private static Mesh ITEM_MESH;
 
-    public UnbakedSlopeModel(Identifier parent) {
+    public UnbakedSlopeModel(net.minecraft.util.Identifier parent) {
         super(parent);
-        this.baseMesh = SlopeFullMesh.getSlopeMesh();
-        this.itemMesh = SlopeFullMesh.getItemMesh();
-        item_state = Blocks.AIR.getDefaultState();
+        this.item_state = Blocks.AIR.getDefaultState();
     }
 
     @Override
-    public BakedModel bake(Baker baker, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings bakeSettings) {
+    public BakedModel bake(
+            Baker baker,
+            Function<SpriteIdentifier, Sprite> textureGetter,
+            ModelBakeSettings bakeSettings
+    ) {
+        initializeMeshes();
+
         return new RetexturingBakedModel(
                 baker.bake(parent, bakeSettings),
                 ReFramedClient.HELPER.getCamoAppearanceManager(textureGetter),
@@ -47,126 +49,167 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         ) {
             @Override
             protected Mesh convertModel(BlockState state) {
-                boolean isItem = state == null || state.isAir();
-
-                if (isItem) {
-                    MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
-                    QuadEmitter emitter = builder.getEmitter();
-
-                    itemMesh.forEach(quad -> {
-                        emitter.copyFrom(quad);
-                        emitter.emit();
-                    });
-
-                    return builder.build();
+                if (state == null || state.isAir()) {
+                    return ITEM_MESH;
                 }
-
-                Edge edge = state.contains(EDGE) ? state.get(EDGE) : Edge.DOWN_SOUTH;
-
-                MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
-                QuadEmitter emitter = builder.getEmitter();
-
-                RenderContext.QuadTransform transform = getTransformForEdge(edge);
-
-                baseMesh.forEach(quad -> {
-                    emitter.copyFrom(quad);
-                    if (transform != null) {
-                        transform.transform(emitter);
-                    }
-                    emitter.emit();
-                });
-
-                return builder.build();
+                return SLOPE_MESHES[state.get(EDGE).getID()];
             }
         };
     }
 
-    private static RenderContext.QuadTransform getTransformForEdge(Edge edge) {
-        Matrix4f matrix = getRotationMatrix(edge);
-        if (matrix == null) return null;
+    private static void initializeMeshes() {
+        if (SLOPE_MESHES[0] != null) return;
 
-        Map<Direction, Direction> faceMap = createFacePermutation(matrix);
+        Mesh baseMesh = SlopeFullMesh.getBaseMesh();
+        ITEM_MESH = baseMesh;
+        Renderer renderer = ReFramedClient.HELPER.getFabricRenderer();
 
-        return quad -> {
-            float[] originalU = new float[4];
-            float[] originalV = new float[4];
-            for (int i = 0; i < 4; i++) {
-                originalU[i] = quad.u(i);
-                originalV[i] = quad.v(i);
+        for (Edge edge : Edge.values()) {
+            Direction targetBase;
+            Direction targetBack;
+
+            switch (edge) {
+                case DOWN_SOUTH -> { targetBase = Direction.DOWN; targetBack = Direction.NORTH; }
+                case NORTH_DOWN -> { targetBase = Direction.DOWN; targetBack = Direction.SOUTH; }
+                case DOWN_EAST -> { targetBase = Direction.DOWN; targetBack = Direction.EAST; }
+                case WEST_DOWN -> { targetBase = Direction.DOWN; targetBack = Direction.WEST; }
+                case SOUTH_UP -> { targetBase = Direction.UP; targetBack = Direction.NORTH; }
+                case UP_NORTH -> { targetBase = Direction.UP; targetBack = Direction.SOUTH; }
+                case EAST_UP -> { targetBase = Direction.UP; targetBack = Direction.WEST; }
+                case UP_WEST -> { targetBase = Direction.UP; targetBack = Direction.EAST; }
+                case EAST_SOUTH -> { targetBase = Direction.EAST; targetBack = Direction.NORTH; }
+                case SOUTH_WEST -> { targetBase = Direction.WEST; targetBack = Direction.NORTH; }
+                case NORTH_EAST -> { targetBase = Direction.WEST; targetBack = Direction.SOUTH; }
+                case WEST_NORTH -> { targetBase = Direction.EAST; targetBack = Direction.SOUTH; }
+                default -> { targetBase = Direction.DOWN; targetBack = Direction.SOUTH; }
             }
 
-            Vector3f pos = new Vector3f();
-            for (int i = 0; i < 4; i++) {
-                quad.copyPos(i, pos);
-                pos.sub(0.5f, 0.5f, 0.5f);
-                pos.mulPosition(matrix);
-                pos.add(0.5f, 0.5f, 0.5f);
-                quad.pos(i, pos.x(), pos.y(), pos.z());
-            }
+            Matrix4f transform = computeTransformForBaseBack(targetBase, targetBack);
 
-            for (int i = 0; i < 4; i++) {
-                quad.uv(i, originalU[i], originalV[i]);
-            }
-
-            Direction oldCull = quad.cullFace();
-            if (oldCull != null) {
-                quad.cullFace(faceMap.get(oldCull));
-            }
-
-            Direction oldNominal = quad.nominalFace();
-            if (oldNominal != null) {
-                Direction newNominal = faceMap.get(oldNominal);
-                quad.nominalFace(newNominal);
-                quad.tag(newNominal.ordinal() + 1);
-            }
-
-            return true;
-        };
+            SLOPE_MESHES[edge.getID()] = transformMesh(renderer, baseMesh, transform, edge);
+        }
     }
 
-    private static Matrix4f getRotationMatrix(Edge edge) {
+    private static Matrix4f computeTransformForBaseBack(Direction base, Direction back) {
         Matrix4f matrix = new Matrix4f().identity();
 
-        switch (edge) {
-            case DOWN_SOUTH -> { return null; }
-            case NORTH_DOWN -> matrix.rotateY((float) Math.PI);
-            case UP_NORTH -> matrix.rotateX((float) Math.PI);
-            case SOUTH_UP -> {
-                matrix.rotateY((float) Math.PI);
-                matrix.rotateX((float) Math.PI);
-            }
+        matrix.mul(getRotationFromDown(base));
 
-            case DOWN_EAST -> matrix.rotateY((float) (Math.PI / 2));
-            case WEST_DOWN -> matrix.rotateY((float) (-Math.PI / 2));
-            case EAST_UP -> {
-                matrix.rotateY((float) (Math.PI / 2));
-                matrix.rotateX((float) Math.PI);
-                matrix.rotateY((float) Math.PI);
-            }
-
-            case UP_WEST -> {
-                matrix.rotateY((float) (-Math.PI / 2));
-                matrix.rotateX((float) Math.PI);
-                matrix.rotateY((float) Math.PI);
-            }
-
-            case EAST_SOUTH -> matrix.rotateZ((float) (-Math.PI / 2));
-            case WEST_NORTH -> matrix.rotateZ((float) (Math.PI / 2));
-            case NORTH_EAST -> matrix.rotateZ((float) Math.PI);
-            case SOUTH_WEST -> {
-                matrix.rotateX((float) Math.PI);
-                matrix.rotateZ((float) (-Math.PI / 2));
-            }
-        }
+        matrix.mul(getRotationAroundAxis(base, back));
 
         return matrix;
     }
 
-    private static Map<Direction, Direction> createFacePermutation(Matrix4f matrix) {
+    private static Matrix4f getRotationFromDown(Direction target) {
+        Matrix4f m = new Matrix4f().identity();
+        return switch (target) {
+            case DOWN -> m;
+            case UP -> m.rotateX((float) Math.PI);
+            case NORTH -> m.rotateX((float) Math.PI / 2f);
+            case SOUTH -> m.rotateX(-(float) Math.PI / 2f);
+            case WEST -> m.rotateZ(-(float) Math.PI / 2f);
+            case EAST -> m.rotateZ((float) Math.PI / 2f);
+        };
+    }
+
+    private static Matrix4f getRotationAroundAxis(Direction base, Direction back) {
+        Direction defaultBack = switch (base) {
+            case DOWN -> Direction.SOUTH;
+            case UP -> Direction.NORTH;
+            case NORTH -> Direction.DOWN;
+            case SOUTH -> Direction.UP;
+            case WEST -> Direction.SOUTH;
+            case EAST -> Direction.SOUTH;
+        };
+
+        float angle = computeRotationAngle(base, defaultBack, back);
+
+        Matrix4f m = new Matrix4f().identity();
+        if (angle == 0f) return m;
+
+        return switch (base.getAxis()) {
+            case X -> m.rotateX(angle);
+            case Y -> m.rotateY(angle);
+            case Z -> m.rotateZ(angle);
+        };
+    }
+
+    private static float computeRotationAngle(Direction base, Direction from, Direction to) {
+        Direction[] perpendiculars = switch (base) {
+            case DOWN, UP -> new Direction[]{Direction.SOUTH, Direction.WEST, Direction.NORTH, Direction.EAST};
+            case NORTH, SOUTH -> new Direction[]{Direction.UP, Direction.WEST, Direction.DOWN, Direction.EAST};
+            case WEST, EAST -> new Direction[]{Direction.UP, Direction.NORTH, Direction.DOWN, Direction.SOUTH};
+        };
+
+        int fromIndex = -1, toIndex = -1;
+        for (int i = 0; i < perpendiculars.length; i++) {
+            if (perpendiculars[i] == from) fromIndex = i;
+            if (perpendiculars[i] == to) toIndex = i;
+        }
+
+        if (fromIndex == -1 || toIndex == -1) return 0f;
+
+        int steps = (toIndex - fromIndex + 4) % 4;
+        return steps * (float) Math.PI / 2f;
+    }
+
+    private static Mesh transformMesh(Renderer renderer, Mesh source, Matrix4f matrix, Edge edge) {
+        MeshBuilder builder = renderer.meshBuilder();
+        QuadEmitter emitter = builder.getEmitter();
+
+        Map<Direction, Direction> faceMap = createFaceMapping(matrix);
+
+        source.forEach(quad -> {
+            emitter.copyFrom(quad);
+
+            Vector3f pos = new Vector3f();
+            for (int i = 0; i < 4; i++) {
+                emitter.copyPos(i, pos);
+                pos.sub(0.5f, 0.5f, 0.5f);
+                pos.mulPosition(matrix);
+                pos.add(0.5f, 0.5f, 0.5f);
+                emitter.pos(i, pos.x(), pos.y(), pos.z());
+            }
+
+            Direction cullFace = quad.cullFace();
+            if (cullFace != null) emitter.cullFace(faceMap.get(cullFace));
+
+            Direction nominalFace = quad.nominalFace();
+            if (nominalFace != null) {
+                Direction newNominal = faceMap.get(nominalFace);
+                emitter.nominalFace(newNominal);
+                emitter.tag(newNominal.ordinal() + 1);
+            }
+
+            emitter.emit();
+        });
+
+        return builder.build();
+    }
+
+    private static Map<Direction, Direction> createFaceMapping(Matrix4f matrix) {
         Map<Direction, Direction> map = new EnumMap<>(Direction.class);
         for (Direction dir : Direction.values()) {
-            map.put(dir, Direction.transform(matrix, dir));
+            map.put(dir, transformDirection(matrix, dir));
         }
         return map;
+    }
+
+    private static Direction transformDirection(Matrix4f matrix, Direction dir) {
+        Vector3f vec = dir.getUnitVector();
+        vec.mulDirection(matrix);
+
+        Direction closest = Direction.UP;
+        float maxDot = -1f;
+
+        for (Direction d : Direction.values()) {
+            float dot = vec.dot(d.getUnitVector());
+            if (dot > maxDot) {
+                maxDot = dot;
+                closest = d;
+            }
+        }
+
+        return closest;
     }
 }

--- a/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
+++ b/src/main/java/fr/adrien1106/reframed/client/model/UnbakedSlopeModel.java
@@ -1,6 +1,5 @@
 package fr.adrien1106.reframed.client.model;
 
-import fr.adrien1106.reframed.block.ReFramedSlopeFullBlock;
 import fr.adrien1106.reframed.client.ReFramedClient;
 import fr.adrien1106.reframed.util.blocks.Edge;
 import net.fabricmc.fabric.api.renderer.v1.mesh.Mesh;
@@ -28,10 +27,12 @@ import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
 public class UnbakedSlopeModel extends UnbakedRetexturedModel {
 
     private final Mesh baseMesh;
+    private final Mesh itemMesh;
 
     public UnbakedSlopeModel(Identifier parent) {
         super(parent);
         this.baseMesh = SlopeFullMesh.getSlopeMesh();
+        this.itemMesh = SlopeFullMesh.getItemMesh();
         item_state = Blocks.AIR.getDefaultState();
     }
 
@@ -46,18 +47,27 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         ) {
             @Override
             protected Mesh convertModel(BlockState state) {
-                // Get the edge from the blockstate
-                Edge edge = state != null && state.contains(EDGE)
-                        ? state.get(EDGE)
-                        : Edge.DOWN_SOUTH;
+                boolean isItem = state == null || state.isAir();
+
+                if (isItem) {
+                    MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
+                    QuadEmitter emitter = builder.getEmitter();
+
+                    itemMesh.forEach(quad -> {
+                        emitter.copyFrom(quad);
+                        emitter.emit();
+                    });
+
+                    return builder.build();
+                }
+
+                Edge edge = state.contains(EDGE) ? state.get(EDGE) : Edge.DOWN_SOUTH;
 
                 MeshBuilder builder = ReFramedClient.HELPER.getFabricRenderer().meshBuilder();
                 QuadEmitter emitter = builder.getEmitter();
 
-                // Get transformation for this edge orientation
                 RenderContext.QuadTransform transform = getTransformForEdge(edge);
 
-                // Apply transformation to base mesh
                 baseMesh.forEach(quad -> {
                     emitter.copyFrom(quad);
                     if (transform != null) {
@@ -71,10 +81,6 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         };
     }
 
-    /**
-     * Get the transformation to apply based on the Edge orientation.
-     * Base mesh is oriented for Edge.DOWN_SOUTH (slope rising from north to south)
-     */
     private static RenderContext.QuadTransform getTransformForEdge(Edge edge) {
         Matrix4f matrix = getRotationMatrix(edge);
         if (matrix == null) return null;
@@ -82,17 +88,26 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         Map<Direction, Direction> faceMap = createFacePermutation(matrix);
 
         return quad -> {
-            // Transform vertex positions
+            float[] originalU = new float[4];
+            float[] originalV = new float[4];
+            for (int i = 0; i < 4; i++) {
+                originalU[i] = quad.u(i);
+                originalV[i] = quad.v(i);
+            }
+
             Vector3f pos = new Vector3f();
             for (int i = 0; i < 4; i++) {
                 quad.copyPos(i, pos);
-                pos.sub(0.5f, 0.5f, 0.5f); // Center around origin
-                pos.mulPosition(matrix);    // Apply rotation
-                pos.add(0.5f, 0.5f, 0.5f); // Move back
+                pos.sub(0.5f, 0.5f, 0.5f);
+                pos.mulPosition(matrix);
+                pos.add(0.5f, 0.5f, 0.5f);
                 quad.pos(i, pos.x(), pos.y(), pos.z());
             }
 
-            // Transform face directions
+            for (int i = 0; i < 4; i++) {
+                quad.uv(i, originalU[i], originalV[i]);
+            }
+
             Direction oldCull = quad.cullFace();
             if (oldCull != null) {
                 quad.cullFace(faceMap.get(oldCull));
@@ -109,37 +124,31 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         };
     }
 
-    /**
-     * Get the rotation matrix for transforming from base orientation (DOWN_SOUTH)
-     * to the target edge orientation
-     */
     private static Matrix4f getRotationMatrix(Edge edge) {
         Matrix4f matrix = new Matrix4f().identity();
 
         switch (edge) {
-            case DOWN_SOUTH -> { return null; } // Base orientation, no transform
-            case NORTH_DOWN -> matrix.rotateY((float) Math.PI); // 180° around Y
-            case UP_NORTH -> matrix.rotateX((float) Math.PI); // 180° around X
-            case SOUTH_UP -> { // 180° around Y, then 180° around X
+            case DOWN_SOUTH -> { return null; }
+            case NORTH_DOWN -> matrix.rotateY((float) Math.PI);
+            case UP_NORTH -> matrix.rotateX((float) Math.PI);
+            case SOUTH_UP -> {
                 matrix.rotateY((float) Math.PI);
                 matrix.rotateX((float) Math.PI);
             }
-            case DOWN_EAST -> matrix.rotateY((float) (Math.PI / 2)); // 90° CW around Y
-            case WEST_DOWN -> matrix.rotateY((float) (-Math.PI / 2)); // 90° CCW around Y
-            case EAST_UP -> { // 90° CW around Y, then 180° around X
+            case DOWN_EAST -> matrix.rotateY((float) (Math.PI / 2));
+            case WEST_DOWN -> matrix.rotateY((float) (-Math.PI / 2));
+            case EAST_UP -> {
                 matrix.rotateY((float) (Math.PI / 2));
                 matrix.rotateX((float) Math.PI);
             }
-            case UP_WEST -> { // 90° CCW around Y, then 180° around X
+            case UP_WEST -> {
                 matrix.rotateY((float) (-Math.PI / 2));
                 matrix.rotateX((float) Math.PI);
             }
-            case EAST_SOUTH -> matrix.rotateZ((float) (-Math.PI / 2)); // 90° CW around Z
-            case WEST_NORTH -> matrix.rotateZ((float) (Math.PI / 2)); // 90° CCW around Z
-            case NORTH_EAST -> { // 180° around Z
-                matrix.rotateZ((float) Math.PI);
-            }
-            case SOUTH_WEST -> { // 180° around X, then 90° CW around Z
+            case EAST_SOUTH -> matrix.rotateZ((float) (-Math.PI / 2));
+            case WEST_NORTH -> matrix.rotateZ((float) (Math.PI / 2));
+            case NORTH_EAST -> matrix.rotateZ((float) Math.PI);
+            case SOUTH_WEST -> {
                 matrix.rotateX((float) Math.PI);
                 matrix.rotateZ((float) (-Math.PI / 2));
             }
@@ -148,9 +157,6 @@ public class UnbakedSlopeModel extends UnbakedRetexturedModel {
         return matrix;
     }
 
-    /**
-     * Create a map of how directions transform under the given matrix
-     */
     private static Map<Direction, Direction> createFacePermutation(Matrix4f matrix) {
         Map<Direction, Direction> map = new EnumMap<>(Direction.class);
         for (Direction dir : Direction.values()) {

--- a/src/main/java/fr/adrien1106/reframed/generator/GBlockstate.java
+++ b/src/main/java/fr/adrien1106/reframed/generator/GBlockstate.java
@@ -10,6 +10,7 @@ import net.minecraft.data.client.*;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.Identifier;
 import fr.adrien1106.reframed.generator.block.Carpet;
+import fr.adrien1106.reframed.generator.block.SlopeFull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +22,7 @@ public class GBlockstate extends FabricModelProvider {
     private static final Map<Class<? extends Block>, BlockStateProvider> providers = new HashMap<>();
     static {
         providers.put(ReFramedCarpetBlock.class, new Carpet());
+        providers.put(ReFramedSlopeFullBlock.class, new SlopeFull());
         providers.put(ReFramedHalfStairBlock.class, new HalfStair());
         providers.put(ReFramedHalfStairsSlabBlock.class, new HalfStairsSlab());
         providers.put(ReFramedHalfStairsStairBlock.class, new HalfStairsStair());

--- a/src/main/java/fr/adrien1106/reframed/generator/GBlockstate.java
+++ b/src/main/java/fr/adrien1106/reframed/generator/GBlockstate.java
@@ -9,6 +9,7 @@ import net.minecraft.block.Block;
 import net.minecraft.data.client.*;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.Identifier;
+import fr.adrien1106.reframed.generator.block.Carpet;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +20,7 @@ import static net.minecraft.data.client.VariantSettings.Rotation.R0;
 public class GBlockstate extends FabricModelProvider {
     private static final Map<Class<? extends Block>, BlockStateProvider> providers = new HashMap<>();
     static {
+        providers.put(ReFramedCarpetBlock.class, new Carpet());
         providers.put(ReFramedHalfStairBlock.class, new HalfStair());
         providers.put(ReFramedHalfStairsSlabBlock.class, new HalfStairsSlab());
         providers.put(ReFramedHalfStairsStairBlock.class, new HalfStairsStair());
@@ -64,17 +66,23 @@ public class GBlockstate extends FabricModelProvider {
         ReFramed.BLOCKS
             .forEach(model_generator::excludeFromSimpleItemModelGeneration);
         ReFramed.BLOCKS.stream()
-            .map(block -> {
-                if (providers.containsKey(block.getClass())) return providers.get(block.getClass()).getMultipart(block);
-                return VariantsBlockStateSupplier.create(
-                    block,
-                    GBlockstate.variant(
-                        ReFramed.id("cube_special"),
-                        true,
-                        R0, R0
-                    )
-                );
-            })
+                .map(block -> {
+                    if (providers.containsKey(block.getClass())) {
+                        BlockStateProvider provider = providers.get(block.getClass());
+                        if (provider instanceof Carpet carpet) {
+                            return carpet.getVariant(block);
+                        }
+                        return provider.getMultipart(block);
+                    }
+                    return VariantsBlockStateSupplier.create(
+                            block,
+                            GBlockstate.variant(
+                                    ReFramed.id("cube_special"),
+                                    true,
+                                    R0, R0
+                            )
+                    );
+                })
             .filter(Objects::nonNull)
             .forEach(model_generator.blockStateCollector);
     }

--- a/src/main/java/fr/adrien1106/reframed/generator/block/Carpet.java
+++ b/src/main/java/fr/adrien1106/reframed/generator/block/Carpet.java
@@ -1,0 +1,43 @@
+package fr.adrien1106.reframed.generator.block;
+
+import fr.adrien1106.reframed.ReFramed;
+import fr.adrien1106.reframed.generator.BlockStateProvider;
+import fr.adrien1106.reframed.generator.RecipeSetter;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
+import net.minecraft.block.Block;
+import net.minecraft.data.client.MultipartBlockStateSupplier;
+import net.minecraft.data.client.VariantsBlockStateSupplier;
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.data.server.recipe.RecipeProvider;
+import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.recipe.book.RecipeCategory;
+
+import static fr.adrien1106.reframed.generator.GBlockstate.variant;
+import static net.minecraft.data.client.VariantSettings.Rotation.R0;
+
+public class Carpet implements RecipeSetter, BlockStateProvider {
+
+    @Override
+    public void setRecipe(RecipeExporter exporter, ItemConvertible convertible) {
+        ShapedRecipeJsonBuilder
+                .create(RecipeCategory.BUILDING_BLOCKS, convertible, 3)
+                .pattern("II")
+                .input('I', ReFramed.CUBE)
+                .criterion(FabricRecipeProvider.hasItem(ReFramed.CUBE), FabricRecipeProvider.conditionsFromItem(ReFramed.CUBE))
+                .criterion(FabricRecipeProvider.hasItem(convertible), FabricRecipeProvider.conditionsFromItem(convertible))
+                .offerTo(exporter);
+    }
+
+    @Override
+    public MultipartBlockStateSupplier getMultipart(Block block) {
+        return null;
+    }
+
+    public VariantsBlockStateSupplier getVariant(Block block) {
+        return VariantsBlockStateSupplier.create(
+                block,
+                variant(ReFramed.id("carpet_special"), true, R0, R0)
+        );
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/generator/block/SlopeFull.java
+++ b/src/main/java/fr/adrien1106/reframed/generator/block/SlopeFull.java
@@ -1,0 +1,69 @@
+package fr.adrien1106.reframed.generator.block;
+
+import fr.adrien1106.reframed.ReFramed;
+import fr.adrien1106.reframed.generator.BlockStateProvider;
+import fr.adrien1106.reframed.generator.GBlockstate;
+import fr.adrien1106.reframed.generator.RecipeSetter;
+import fr.adrien1106.reframed.util.blocks.Edge;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
+import net.minecraft.block.Block;
+import net.minecraft.data.client.MultipartBlockStateSupplier;
+import net.minecraft.data.server.recipe.RecipeExporter;
+import net.minecraft.data.server.recipe.RecipeProvider;
+import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.recipe.book.RecipeCategory;
+import net.minecraft.util.Identifier;
+
+import static fr.adrien1106.reframed.util.blocks.BlockProperties.EDGE;
+import static net.minecraft.data.client.VariantSettings.Rotation.*;
+
+public class SlopeFull implements RecipeSetter, BlockStateProvider {
+
+    @Override
+    public void setRecipe(RecipeExporter exporter, ItemConvertible convertible) {
+        RecipeProvider.offerStonecuttingRecipe(exporter, RecipeCategory.BUILDING_BLOCKS, convertible, ReFramed.CUBE, 2);
+        ShapedRecipeJsonBuilder
+                .create(RecipeCategory.BUILDING_BLOCKS, convertible, 6)
+                .pattern("  I")
+                .pattern(" II")
+                .pattern("III")
+                .input('I', ReFramed.CUBE)
+                .criterion(FabricRecipeProvider.hasItem(ReFramed.CUBE), FabricRecipeProvider.conditionsFromItem(ReFramed.CUBE))
+                .criterion(FabricRecipeProvider.hasItem(convertible), FabricRecipeProvider.conditionsFromItem(convertible))
+                .offerTo(exporter);
+    }
+
+    @Override
+    public MultipartBlockStateSupplier getMultipart(Block block) {
+        Identifier model_id = ReFramed.id("slope_full_special");
+        return MultipartBlockStateSupplier.create(block)
+
+                .with(GBlockstate.when(EDGE, Edge.NORTH_DOWN),
+                        GBlockstate.variant(model_id, true, R0, R270))
+                .with(GBlockstate.when(EDGE, Edge.DOWN_SOUTH),
+                        GBlockstate.variant(model_id, true, R0, R90))
+                .with(GBlockstate.when(EDGE, Edge.SOUTH_UP),
+                        GBlockstate.variant(model_id, true, R180, R90))
+                .with(GBlockstate.when(EDGE, Edge.UP_NORTH),
+                        GBlockstate.variant(model_id, true, R180, R270))
+
+                .with(GBlockstate.when(EDGE, Edge.WEST_DOWN),
+                        GBlockstate.variant(model_id, true, R0, R180))
+                .with(GBlockstate.when(EDGE, Edge.DOWN_EAST),
+                        GBlockstate.variant(model_id, true, R0, R0))
+                .with(GBlockstate.when(EDGE, Edge.EAST_UP),
+                        GBlockstate.variant(model_id, true, R180, R0))
+                .with(GBlockstate.when(EDGE, Edge.UP_WEST),
+                        GBlockstate.variant(model_id, true, R180, R180))
+
+                .with(GBlockstate.when(EDGE, Edge.WEST_NORTH),
+                        GBlockstate.variant(model_id, true, R90, R180))
+                .with(GBlockstate.when(EDGE, Edge.NORTH_EAST),
+                        GBlockstate.variant(model_id, true, R90, R270))
+                .with(GBlockstate.when(EDGE, Edge.EAST_SOUTH),
+                        GBlockstate.variant(model_id, true, R90, R0))
+                .with(GBlockstate.when(EDGE, Edge.SOUTH_WEST),
+                        GBlockstate.variant(model_id, true, R90, R90));
+    }
+}

--- a/src/main/java/fr/adrien1106/reframed/item/ReFramedScrewdriverItem.java
+++ b/src/main/java/fr/adrien1106/reframed/item/ReFramedScrewdriverItem.java
@@ -2,6 +2,7 @@ package fr.adrien1106.reframed.item;
 
 import fr.adrien1106.reframed.ReFramed;
 import fr.adrien1106.reframed.block.ReFramedDoubleBlock;
+import fr.adrien1106.reframed.block.ReFramedTrapdoorBlock;
 import fr.adrien1106.reframed.util.blocks.ThemeableBlockEntity;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -42,6 +43,18 @@ public class ReFramedScrewdriverItem extends Item {
                 if (otherState.isOf(door)) {
                     world.setBlockState(otherPos, otherState.with(ReFramedDoorBlock.HAND_OPENABLE, newValue), 3);
                 }
+
+                BlockSoundGroup group = state.getSoundGroup();
+                world.playSound(player, pos, group.getPlaceSound(), SoundCategory.BLOCKS, group.getVolume(), group.getPitch());
+            }
+            return ActionResult.success(world.isClient);
+        }
+
+        if (state.getBlock() instanceof ReFramedTrapdoorBlock) {
+            if (!world.isClient && player != null) {
+
+                boolean newValue = !state.get(ReFramedTrapdoorBlock.HAND_OPENABLE);
+                world.setBlockState(pos, state.with(ReFramedTrapdoorBlock.HAND_OPENABLE, newValue), 3);
 
                 BlockSoundGroup group = state.getSoundGroup();
                 world.playSound(player, pos, group.getPlaceSound(), SoundCategory.BLOCKS, group.getVolume(), group.getPitch());

--- a/src/main/java/fr/adrien1106/reframed/item/ReFramedScrewdriverItem.java
+++ b/src/main/java/fr/adrien1106/reframed/item/ReFramedScrewdriverItem.java
@@ -14,6 +14,9 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import fr.adrien1106.reframed.block.ReFramedDoorBlock;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.enums.DoubleBlockHalf;
 
 public class ReFramedScrewdriverItem extends Item {
 
@@ -25,22 +28,40 @@ public class ReFramedScrewdriverItem extends Item {
     public ActionResult useOnBlock(ItemUsageContext context) {
         World world = context.getWorld();
         BlockPos pos = context.getBlockPos();
+        PlayerEntity player = context.getPlayer();
+        BlockState state = world.getBlockState(pos);
 
-        if (!(world.getBlockEntity(pos) instanceof ThemeableBlockEntity frame_entity)) {
+        if (state.getBlock() instanceof ReFramedDoorBlock door) {
+            if (!world.isClient && player != null) {
+
+                BlockPos otherPos = state.get(Properties.DOUBLE_BLOCK_HALF) == DoubleBlockHalf.LOWER ? pos.up() : pos.down();
+                BlockState otherState = world.getBlockState(otherPos);
+
+                boolean newValue = !state.get(ReFramedDoorBlock.HAND_OPENABLE);
+                world.setBlockState(pos, state.with(ReFramedDoorBlock.HAND_OPENABLE, newValue), 3);
+                if (otherState.isOf(door)) {
+                    world.setBlockState(otherPos, otherState.with(ReFramedDoorBlock.HAND_OPENABLE, newValue), 3);
+                }
+
+                BlockSoundGroup group = state.getSoundGroup();
+                world.playSound(player, pos, group.getPlaceSound(), SoundCategory.BLOCKS, group.getVolume(), group.getPitch());
+            }
+            return ActionResult.success(world.isClient);
+        }
+
+        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (!(blockEntity instanceof ThemeableBlockEntity frame_entity)) {
             return ActionResult.PASS;
         }
 
-        BlockState state = world.getBlockState(pos);
-
-        PlayerEntity player = context.getPlayer();
         int theme_index = state.getBlock() instanceof ReFramedDoubleBlock b
-            ? b.getHitShape(
+                ? b.getHitShape(
                 state,
                 context.getHitPos(),
                 context.getBlockPos(),
                 context.getSide()
-            )
-            : 1;
+        )
+                : 1;
 
         BlockState theme = frame_entity.getTheme(theme_index);
 
@@ -50,14 +71,16 @@ public class ReFramedScrewdriverItem extends Item {
         BlockSoundGroup group = theme.getSoundGroup();
         world.playSound(player, pos, group.getPlaceSound(), SoundCategory.BLOCKS, group.getVolume(), group.getPitch());
         frame_entity.setTheme(theme.with(
-            Properties.AXIS,
-            switch (axis) {
-                case X -> Direction.Axis.Y;
-                case Y -> Direction.Axis.Z;
-                case Z -> Direction.Axis.X;
-            }
+                Properties.AXIS,
+                switch (axis) {
+                    case X -> Direction.Axis.Y;
+                    case Y -> Direction.Axis.Z;
+                    case Z -> Direction.Axis.X;
+                }
         ), theme_index);
+
         if (world.isClient) ReFramed.chunkRerenderProxy.accept(world, pos);
+
         return ActionResult.SUCCESS;
     }
 }

--- a/src/main/resources/assets/reframed/models/block/carpet.json
+++ b/src/main/resources/assets/reframed/models/block/carpet.json
@@ -1,0 +1,35 @@
+{
+  "credit": "Made with Blockbench",
+  "parent": "block/block",
+  "textures": {
+    "particle": "#side"
+  },
+  "elements": [
+    {
+      "from": [0, 0, 0],
+      "to": [16, 1, 16],
+      "faces": {
+        "north": {"uv": [0, 15, 16, 16], "texture": "#side", "cullface": "north"},
+        "east": {"uv": [0, 15, 16, 16], "texture": "#side", "cullface": "east"},
+        "south": {"uv": [0, 15, 16, 16], "texture": "#side", "cullface": "south"},
+        "west": {"uv": [0, 15, 16, 16], "texture": "#side", "cullface": "west"},
+        "up": {"uv": [0, 0, 16, 16], "texture": "#top"},
+        "down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
+      }
+    }
+  ],
+  "display": {
+    "thirdperson_lefthand": {
+      "rotation": [75, -135, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.375, 0.375, 0.375]
+    },
+    "gui": {
+      "rotation": [30, 135, 0],
+      "scale": [0.625, 0.625, 0.625]
+    },
+    "head": {
+      "rotation": [0, -90, 0]
+    }
+  }
+}

--- a/src/main/resources/assets/reframed/models/block/slope_full.json
+++ b/src/main/resources/assets/reframed/models/block/slope_full.json
@@ -1,0 +1,31 @@
+{
+  "parent": "minecraft:block/block",
+  "gui_light": "front",
+  "display": {
+    "firstperson_righthand": {
+      "rotation": [ 0, 135, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 0.40, 0.40, 0.40 ]
+    },
+    "firstperson_lefthand": {
+      "rotation": [ 0, 135, 0 ],
+      "translation": [ 0, 0, 0 ],
+      "scale": [ 0.40, 0.40, 0.40 ]
+    },
+    "thirdperson_righthand": {
+      "rotation": [ 75, -225, 0 ],
+      "translation": [ 0, 2.5, 0],
+      "scale": [ 0.375, 0.375, 0.375 ]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [ 75, -225, 0 ],
+      "translation": [ 0, 2.5, 0],
+      "scale": [ 0.375, 0.375, 0.375 ]
+    },
+    "fixed": {
+      "rotation": [ 0, 90, 0 ],
+      "translation": [ 0, 0, 0],
+      "scale":[ 0.5, 0.5, 0.5 ]
+    }
+  }
+}

--- a/src/main/resources/assets/reframed/models/block/slope_full.json
+++ b/src/main/resources/assets/reframed/models/block/slope_full.json
@@ -3,27 +3,31 @@
   "gui_light": "front",
   "display": {
     "firstperson_righthand": {
-      "rotation": [ 0, 135, 0 ],
+      "rotation": [ 0, 315, 0 ],
       "translation": [ 0, 0, 0 ],
       "scale": [ 0.40, 0.40, 0.40 ]
     },
     "firstperson_lefthand": {
-      "rotation": [ 0, 135, 0 ],
+      "rotation": [ 0, 315, 0 ],
       "translation": [ 0, 0, 0 ],
       "scale": [ 0.40, 0.40, 0.40 ]
     },
     "thirdperson_righthand": {
-      "rotation": [ 75, -225, 0 ],
+      "rotation": [ 75, 45, 0 ],
       "translation": [ 0, 2.5, 0],
       "scale": [ 0.375, 0.375, 0.375 ]
     },
     "thirdperson_lefthand": {
-      "rotation": [ 75, -225, 0 ],
+      "rotation": [ 75, 45, 0 ],
       "translation": [ 0, 2.5, 0],
       "scale": [ 0.375, 0.375, 0.375 ]
     },
+    "gui": {
+      "rotation": [ 30, 225, 0 ],
+      "scale": [ 0.625, 0.625, 0.625 ]
+    },
     "fixed": {
-      "rotation": [ 0, 90, 0 ],
+      "rotation": [ 0, 270, 0 ],
       "translation": [ 0, 0, 0],
       "scale":[ 0.5, 0.5, 0.5 ]
     }


### PR DESCRIPTION
Added the ability to toggle 'iron' functionality (i.e. can only be opened by redstone, can't be opened by hand) to framed doors and trapdoors by shift right clicking with the screwdriver. This is as an alternative to creating new, separate 'iron door' and 'iron trapdoor' blocks, as `ReFramedDoorBlock` and `ReFramedTrapdoorBlock` don't extend `DoorBlock`/`TrapdoorBlock` so don't accept `BlockSetType`, so creating new blocks would be non-trivial/unnecessary duplication of code.